### PR TITLE
Don't autorevoke the bidder token account

### DIFF
--- a/js/packages/common/src/models/account.ts
+++ b/js/packages/common/src/models/account.ts
@@ -76,6 +76,8 @@ export function approve(
   );
 
   if (autoRevoke) {
+    console.trace();
+    // This is the command that's failing
     cleanupInstructions.push(
       Token.createRevokeInstruction(tokenProgram, account, owner, []),
     );

--- a/js/packages/web/src/actions/cancelBid.ts
+++ b/js/packages/web/src/actions/cancelBid.ts
@@ -77,6 +77,7 @@ export async function sendCancelBid(
     ) &&
     auctionView.auction.info.ended()
   ) {
+    // Here's where we redeem
     await claimUnusedPrizes(
       connection,
       wallet,

--- a/js/packages/web/src/actions/sendPlaceBid.ts
+++ b/js/packages/web/src/actions/sendPlaceBid.ts
@@ -143,6 +143,8 @@ export async function setupPlaceBid(
     toPublicKey(receivingSolAccountOrAta),
     wallet.publicKey,
     lamports - accountRentExempt,
+    // I think we should never auto-revoke, since the bidder pot is a PDA and can't be closed anyway.
+    false,
   );
 
   signers.push(transferAuthority);

--- a/js/packages/web/src/actions/sendRedeemBid.ts
+++ b/js/packages/web/src/actions/sendRedeemBid.ts
@@ -796,6 +796,8 @@ export async function setupRedeemParticipationInstructions(
       toPublicKey(receivingSolAccountOrAta),
       wallet.publicKey,
       price,
+      // Probably false since this token account is a PDA
+      false,
     );
 
     mySigners.push(transferAuthority);


### PR DESCRIPTION
## Description

when interacting with a fairly stock auction created through the Metaplex UI, one operation consistently fails: placing bids. here's [a transaction](https://explorer.solana.com/tx/2tVDuWFm9mWafo3unQR1fQuzVuCJTSdqy5edMCyJVYNnRHjc1bBRKGqL5gS2Xc8XR2R4za5YqL57ng3c8Tx7bGkV?cluster=devnet) that fails to place a bid. the one instruction that fails is a "RevokeInstruction" that throws an error about an UninitializedAccount...

digging deeper, this RevokeInstruction is a "cleanup instruction" that is sent along with the [approve](https://github.com/metaplex-foundation/metaplex/blob/master/js/packages/web/src/actions/sendPlaceBid.ts#L140-L146) instruction, with the `tokenAccount` parameter. as of metaplex-foundation/metaplex#1557, though, the tokenAccount here is a PDA instead of a user-created account.

this is where things get slightly out of my wheelhouse — my first instinct is that it is not possible to revoke against a PDA, hence the fix here which skips the revocation instruction entirely (fwiw, after doing that, all the operations including placing a bid / withdrawing items work as expected). OTOH, it is plausible that there's something missing in the bidder pot initialization process, too, which could also cause the revocation failure. i am unsure!